### PR TITLE
Enhance output formatting in example files to use descriptive mode an…

### DIFF
--- a/yy_cybergear/example/exmp_03_position_sin_wave.cpp
+++ b/yy_cybergear/example/exmp_03_position_sin_wave.cpp
@@ -163,14 +163,16 @@ int main(int argc, char ** argv)
         auto r = dev.sendOperationCommand(cmd, timeout_ms);
         if (r.ok()) {
           const auto & st = *r.value();
+          const auto mode_str = yy_cybergear::mode_to_string(st.mode);
+          const auto faults_vec = yy_cybergear::fault_bits_to_string(st.fault_bits);
+          std::string faults_str = faults_vec.empty() ? std::string("none") : faults_vec.front();
+          for (size_t i = 1; i < faults_vec.size(); ++i) faults_str += ", " + faults_vec[i];
           std::cout << std::fixed << std::setprecision(3) << " t=" << t << "s"
                     << " ang=" << st.angle_rad << "rad"
                     << " vel=" << st.vel_rad_s << "rad/s"
                     << " tau=" << st.torque_Nm << "Nm"
                     << " T=" << st.temperature_c << "C"
-                    << " mode=" << static_cast<unsigned>(st.mode) << " faults=0b" << std::uppercase
-                    << std::hex << std::setw(2) << std::setfill('0')
-                    << static_cast<unsigned>(st.fault_bits) << std::dec << " mid=0x"
+                    << " mode=" << mode_str << " faults=" << faults_str << " mid=0x"
                     << std::uppercase << std::hex << std::setw(2) << std::setfill('0')
                     << static_cast<unsigned>(st.motor_can_id) << std::dec << '\n';
 
@@ -195,7 +197,8 @@ int main(int argc, char ** argv)
       if (end > deadline) {
         const auto over = end - deadline;
         const auto over_us = std::chrono::duration_cast<std::chrono::microseconds>(over).count();
-        const auto period_us = std::chrono::duration_cast<std::chrono::microseconds>(dt_ns).count();
+        const auto period_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(dt_ns).count();
         std::cerr << "Control loop overrun: " << over_us << " us past the period (" << period_us
                   << " us). Aborting." << '\n';
         (void)dev.stopMotor();

--- a/yy_cybergear/example/exmp_05_current_constant.cpp
+++ b/yy_cybergear/example/exmp_05_current_constant.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 
 #include "yy_cybergear/cybergear.hpp"
+#include "yy_cybergear/protocol_types.hpp"
 
 using yy_cybergear::CyberGear;
 
@@ -122,14 +123,16 @@ int main(int argc, char ** argv)
         auto r = dev.setIqReference(static_cast<float>(iq_a));
         if (r.ok()) {
           const auto & st = *r.value();
+          const auto mode_str = yy_cybergear::mode_to_string(st.mode);
+          const auto faults_vec = yy_cybergear::fault_bits_to_string(st.fault_bits);
+          std::string faults_str = faults_vec.empty() ? std::string("none") : faults_vec.front();
+          for (size_t i = 1; i < faults_vec.size(); ++i) faults_str += ", " + faults_vec[i];
           std::cout << std::fixed << std::setprecision(3) << " t=" << t << "s"
                     << " ang=" << st.angle_rad << "rad"
                     << " vel=" << st.vel_rad_s << "rad/s"
                     << " tau=" << st.torque_Nm << "Nm"
                     << " T=" << st.temperature_c << "C"
-                    << " mode=" << static_cast<unsigned>(st.mode) << " faults=0b" << std::uppercase
-                    << std::hex << std::setw(2) << std::setfill('0')
-                    << static_cast<unsigned>(st.fault_bits) << std::dec << " mid=0x"
+                    << " mode=" << mode_str << " faults=" << faults_str << " mid=0x"
                     << std::uppercase << std::hex << std::setw(2) << std::setfill('0')
                     << static_cast<unsigned>(st.motor_can_id) << std::dec << '\n';
 
@@ -154,7 +157,8 @@ int main(int argc, char ** argv)
       if (end > deadline) {
         const auto over = end - deadline;
         const auto over_us = std::chrono::duration_cast<std::chrono::microseconds>(over).count();
-        const auto period_us = std::chrono::duration_cast<std::chrono::microseconds>(dt_ns).count();
+        const auto period_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(dt_ns).count();
         std::cerr << "Control loop overrun: " << over_us << " us past the period (" << period_us
                   << " us). Aborting." << '\n';
         (void)dev.stopMotor();


### PR DESCRIPTION
This pull request improves the readability and informativeness of the example output in the CyberGear library by displaying human-readable motor mode and fault information instead of raw numeric values. Additionally, it makes minor formatting changes for code clarity and includes a necessary header for protocol type utilities.

### Output improvements

* The output in `exmp_03_position_sin_wave.cpp`, `exmp_04_speed_constant.cpp`, and `exmp_05_current_constant.cpp` now shows the motor mode as a string and the faults as a comma-separated list of fault names (or "none" if there are no faults), replacing the previous raw numeric representations. [[1]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aR166-R175) [[2]](diffhunk://#diff-b3f27c52809f3053a948d0b36a8c3e4020d5b6155d0ac4d2f4b4eaddef5ca78aR126-R135) [[3]](diffhunk://#diff-aa9fe920262548aa9b57d600b7898a2ce858c3d1a9f2bb2f2ebf8c1085ff6966R126-R135)

### Code formatting and clarity

* Improved formatting for the calculation of the control loop period in microseconds to enhance code readability in all three example files. [[1]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aL198-R201) [[2]](diffhunk://#diff-b3f27c52809f3053a948d0b36a8c3e4020d5b6155d0ac4d2f4b4eaddef5ca78aL158-R161) [[3]](diffhunk://#diff-aa9fe920262548aa9b57d600b7898a2ce858c3d1a9f2bb2f2ebf8c1085ff6966L157-R161)

### Dependency inclusion

* Added `yy_cybergear/protocol_types.hpp` include to `exmp_05_current_constant.cpp` to support new output features.…d fault strings