### PR TITLE
Update: adjust position gain in sine wave example and GUI to improve …

### DIFF
--- a/yy_cybergear/example/exmp_03_operation_sin_wave.cpp
+++ b/yy_cybergear/example/exmp_03_operation_sin_wave.cpp
@@ -47,7 +47,7 @@ int main(int argc, char ** argv)
   // Sine parameters
   double amp_rad = 0.5;     // amplitude [rad]
   double freq_hz = 0.5;     // frequency [Hz]
-  double kp = 50.0;         // position gain
+  double kp = 10.0;         // position gain
   double kd = 1.0;          // velocity gain
   double target_vel = 0.0;  // additional target velocity [rad/s]
   double tau_offset = 0.0;  // offset torque [Nm]

--- a/yy_cybergear/package.xml
+++ b/yy_cybergear/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yy_cybergear</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>CyberGear Cpp Driver</description>
   <maintainer email="yuki8mamo10.hu@gmail.com">yuki yamamoto</maintainer>
   <license>Apache License 2.0</license>

--- a/yy_cybergear_app/package.xml
+++ b/yy_cybergear_app/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yy_cybergear_app</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>CyberGear Qt GUI Application</description>
   <maintainer email="yuki8mamo10.hu@gmail.com">yuki yamamoto</maintainer>
   <license>Apache License 2.0</license>

--- a/yy_cybergear_app/src/main_window.cpp
+++ b/yy_cybergear_app/src/main_window.cpp
@@ -133,7 +133,7 @@ void MainWindow::setupUI()
   m_kpSpin->setRange(0.0, 500.0);
   m_kpSpin->setDecimals(2);
   m_kpSpin->setSingleStep(1.0);
-  m_kpSpin->setValue(50.0);
+  m_kpSpin->setValue(10.0);
   posLayout->addWidget(m_kpSpin, 0, 3);
 
   posLayout->addWidget(new QLabel("Target vel [rad/s] :"), 1, 0);


### PR DESCRIPTION
This pull request includes minor updates to both the driver and GUI application packages, as well as a change to the default position gain parameter in the sine wave operation example and its corresponding UI control. These changes help keep the package versions in sync and adjust the default control gain for improved usability.

Parameter and UI updates:
* Changed the default `kp` (position gain) value from 50.0 to 10.0 in both the sine wave operation example (`exmp_03_operation_sin_wave.cpp`) and the GUI application's position gain spin box (`main_window.cpp`). [[1]](diffhunk://#diff-a1f07fc6375f6954aafc58fa2ae7be9654a9c22998a61acd9d21358a316b08dfL50-R50) [[2]](diffhunk://#diff-43499591a12f4c2ae80b4675d4df9daf843a3f574296dcbce9f0fadf46a8b9eeL136-R136)

Package version increments:
* Updated `yy_cybergear` package version from 0.2.0 to 0.2.1 in `package.xml`.
* Updated `yy_cybergear_app` package version from 0.1.0 to 0.1.1 in `package.xml`.…performance