### PR TITLE
Feat/error handling

### DIFF
--- a/yy_cybergear/example/exmp_01_monitor_status.cpp
+++ b/yy_cybergear/example/exmp_01_monitor_status.cpp
@@ -36,141 +36,20 @@
 #include "yy_cybergear/logging.hpp"
 #include "yy_socket_can/can_runtime.hpp"
 
+#include "exmp_helper.hpp"
+
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
-// Aliases used across helpers
-using Clock = std::chrono::steady_clock;
-
-// Centralized logging lives in yy_cybergear/logging.hpp
-inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
-{
-  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
-}
-
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-// Register a wide handler and dispatch frames into all CyberGear mirrors
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << "\n";
-    }
-  });
-}
-
-// Preflight: issue initial requests and wait until all are ready (with retries)
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  // Initial issue of ReadParam and GetDeviceId
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  // Wait for completion with periodic retries
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-// Wait until user presses Enter (or SIGINT occurs). Returns true if Enter was pressed.
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;  // stdin
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);  // 200 ms timeout
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;  // start on Enter
-      // If other characters were typed, keep polling until newline arrives
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+using exmp_helper::Clock;
 
 }  // namespace
 
@@ -283,7 +162,16 @@ int main(int argc, char ** argv)
             << " Hz. Press Ctrl+C to stop..." << '\n';
 
   // Preflight: request parameters and UID, then wait (without starting the main loop)
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
+
+  // Check for errors after preflight sync
+  for (const auto & cg : cgs) {
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Motor faults detected during initialization. Exiting.\n";
+      rt.stop();
+      return EXIT_FAILURE;
+    }
+  }
 
   // Print collected parameters per motor
   std::cout << "\nCollected parameters (including UID, excluding Status):\n";
@@ -291,7 +179,7 @@ int main(int argc, char ** argv)
     print_params(cg);
   }
   std::cout << "\nPress Enter to start monitoring (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }
@@ -303,6 +191,16 @@ int main(int argc, char ** argv)
       const auto start = Clock::now();
       const auto deadline = start + dt_ns;
       const double t_now = std::chrono::duration<double>(start - t0).count();
+
+      // Check for errors in all motors and exit if any are found
+      for (const auto & cg : cgs) {
+        if (check_for_errors(cg)) {
+          std::cerr << "ERROR: Detected motor faults. Exiting monitor loop.\n";
+          g_running = false;
+          break;
+        }
+      }
+      if (!g_running) break;
 
       for (const auto & cg : cgs) {
         print_status(cg, t_now);
@@ -326,5 +224,6 @@ int main(int argc, char ** argv)
   }
 
   rt.stop();
-  return EXIT_SUCCESS;
+  // Exit with failure if we stopped due to faults
+  return g_running ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/yy_cybergear/example/exmp_02_operation_sin_wave.cpp
+++ b/yy_cybergear/example/exmp_02_operation_sin_wave.cpp
@@ -44,141 +44,20 @@
 #include "yy_cybergear/protocol_types.hpp"
 #include "yy_socket_can/can_runtime.hpp"
 
+#include "exmp_helper.hpp"
+
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
-// Aliases used across helpers (match exmp_05)
-using Clock = std::chrono::steady_clock;
-
-// Centralized logging lives in yy_cybergear/logging.hpp
-inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
-{
-  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
-}
-
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-// Register a wide handler and dispatch frames into all CyberGear mirrors
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << "\n";
-    }
-  });
-}
-
-// Preflight: issue initial requests and wait until all are ready (with retries)
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  // Initial issue of ReadParam and GetDeviceId
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  // Wait for completion with periodic retries
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-// Wait until user presses Enter (or SIGINT occurs). Returns true if Enter was pressed.
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;  // stdin
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);  // 200 ms timeout
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;  // start on Enter
-      // If other characters were typed, keep polling until newline arrives
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+using exmp_helper::Clock;
 
 }  // namespace
 
@@ -315,7 +194,16 @@ int main(int argc, char ** argv)
     yy_cybergear::SPEED_KP,
     yy_cybergear::SPEED_KI,
   };
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
+
+  // Check for errors after preflight sync
+  for (const auto & cg : cgs) {
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Motor faults detected during initialization. Exiting.\n";
+      rt.stop();
+      return EXIT_FAILURE;
+    }
+  }
 
   // Print collected parameters per motor
   std::cout << "\nCollected parameters (including UID, excluding Status):\n";
@@ -324,7 +212,7 @@ int main(int argc, char ** argv)
   }
 
   std::cout << "\nPress Enter to start control (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }
@@ -363,6 +251,16 @@ int main(int argc, char ** argv)
       const auto start = Clock::now();
       const auto deadline = start + dt_ns;
       const double t_now = std::chrono::duration<double>(start - t0).count();
+
+      // Check for errors in all motors and exit if any are found
+      for (const auto & cg : cgs) {
+        if (check_for_errors(cg)) {
+          std::cerr << "ERROR: Stopping all motors due to detected faults.\n";
+          g_running = false;
+          break;
+        }
+      }
+      if (!g_running) break;
 
       // Print snapshot for each motor
       for (const auto & cg : cgs) {
@@ -410,5 +308,6 @@ int main(int argc, char ** argv)
   }
 
   rt.stop();
-  return EXIT_SUCCESS;
+  // Exit with failure if we stopped due to faults
+  return g_running ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/yy_cybergear/example/exmp_03_position_sin_wave.cpp
+++ b/yy_cybergear/example/exmp_03_position_sin_wave.cpp
@@ -44,13 +44,15 @@
 #include "yy_cybergear/logging.hpp"
 #include "yy_socket_can/can_runtime.hpp"
 
+#include "exmp_helper.hpp"
+
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
 // Aliases used across helpers (match exmp_01)
-using Clock = std::chrono::steady_clock;
+using exmp_helper::Clock;
 
 // Centralized logging lives in yy_cybergear/logging.hpp (append command info)
 inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec, double cmd_rad)
@@ -61,127 +63,11 @@ inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec, doubl
   std::cout << oss.str() << '\n';
 }
 
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-// Register a wide handler and dispatch frames into all CyberGear mirrors
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << '\n';
-    }
-  });
-}
-
-// Preflight: issue initial requests and wait until all are ready (with retries)
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  // Initial issue of ReadParam and GetDeviceId
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  // Wait for completion with periodic retries
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-// Wait until user presses Enter (or SIGINT occurs). Returns true if Enter was pressed.
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;  // stdin
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);  // 200 ms timeout
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;  // start on Enter
-      // If other characters were typed, keep polling until newline arrives
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
 
 }  // namespace
 
@@ -309,10 +195,19 @@ int main(int argc, char ** argv)
     yy_cybergear::POSITION_KP,  yy_cybergear::SPEED_KP,
     yy_cybergear::SPEED_KI,
   };
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
   if (!g_running) {
     rt.stop();
     return EXIT_SUCCESS;
+  }
+
+  // Check for errors after preflight sync
+  for (const auto & cg : cgs) {
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Motor faults detected during initialization. Exiting.\n";
+      rt.stop();
+      return EXIT_FAILURE;
+    }
   }
 
   std::cout << "\nCollected parameters (including UID, excluding Status):\n";
@@ -321,7 +216,7 @@ int main(int argc, char ** argv)
   }
 
   std::cout << "\nPress Enter to start control (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }
@@ -375,6 +270,16 @@ int main(int argc, char ** argv)
       const auto start = Clock::now();
       const auto deadline = start + dt_ns;
       const double t_now = std::chrono::duration<double>(start - t0).count();
+
+      // Check for errors in all motors and exit if any are found
+      for (const auto & cg : cgs) {
+        if (check_for_errors(cg)) {
+          std::cerr << "ERROR: Stopping all motors due to detected faults.\n";
+          g_running = false;
+          break;
+        }
+      }
+      if (!g_running) break;
 
       for (std::size_t i = 0; i < cgs.size(); ++i) {
         const double phase = omega * t_now + motor_phases[i];

--- a/yy_cybergear/example/exmp_03_position_sin_wave.cpp
+++ b/yy_cybergear/example/exmp_03_position_sin_wave.cpp
@@ -51,7 +51,7 @@ namespace
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
-// Aliases used across helpers (match exmp_01)
+// Alias used from exmp_helper: Clock
 using exmp_helper::Clock;
 
 // Centralized logging lives in yy_cybergear/logging.hpp (append command info)

--- a/yy_cybergear/example/exmp_04_speed_constant.cpp
+++ b/yy_cybergear/example/exmp_04_speed_constant.cpp
@@ -41,141 +41,20 @@
 #include "yy_cybergear/cybergear.hpp"
 #include "yy_cybergear/logging.hpp"
 #include "yy_socket_can/can_runtime.hpp"
+
+#include "exmp_helper.hpp"
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
-// Aliases used across helpers (match exmp_01)
-using Clock = std::chrono::steady_clock;
-
-// Centralized logging lives in yy_cybergear/logging.hpp
-inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
-{
-  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
-}
-
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-// Register a wide handler and dispatch frames into all CyberGear mirrors
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << "\n";
-    }
-  });
-}
-
-// Preflight: issue initial requests and wait until all are ready (with retries)
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  // Initial issue of ReadParam and GetDeviceId
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  // Wait for completion with periodic retries
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-// Wait until user presses Enter (or SIGINT occurs). Returns true if Enter was pressed.
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;  // stdin
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);  // 200 ms timeout
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;  // start on Enter
-      // If other characters were typed, keep polling until newline arrives
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+using exmp_helper::Clock;
 
 }  // namespace
 
@@ -292,7 +171,16 @@ int main(int argc, char ** argv)
     yy_cybergear::SPEED_KP,
     yy_cybergear::SPEED_KI,
   };
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
+
+  // Check for errors after preflight sync
+  for (const auto & cg : cgs) {
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Motor faults detected during initialization. Exiting.\n";
+      rt.stop();
+      return EXIT_FAILURE;
+    }
+  }
 
   // Print collected parameters per motor
   std::cout << "\nCollected parameters (including UID, excluding Status):\n";
@@ -301,7 +189,7 @@ int main(int argc, char ** argv)
   }
 
   std::cout << "\nPress Enter to start control (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }
@@ -338,6 +226,16 @@ int main(int argc, char ** argv)
       const auto start = Clock::now();
       const auto deadline = start + dt_ns;
       const double t_now = std::chrono::duration<double>(start - t0).count();
+
+      // Check for errors in all motors and exit if any are found
+      for (const auto & cg : cgs) {
+        if (check_for_errors(cg)) {
+          std::cerr << "ERROR: Stopping all motors due to detected faults.\n";
+          g_running = false;
+          break;
+        }
+      }
+      if (!g_running) break;
 
       // Print snapshot for each motor
       for (const auto & cg : cgs) {
@@ -376,5 +274,6 @@ int main(int argc, char ** argv)
   }
 
   rt.stop();
-  return EXIT_SUCCESS;
+  // Exit with failure if we stopped due to faults
+  return g_running ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/yy_cybergear/example/exmp_05_current_constant.cpp
+++ b/yy_cybergear/example/exmp_05_current_constant.cpp
@@ -42,141 +42,20 @@
 #include "yy_cybergear/logging.hpp"
 #include "yy_socket_can/can_runtime.hpp"
 
+#include "exmp_helper.hpp"
+
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
 
-// Aliases used across helpers (match exmp_04)
-using Clock = std::chrono::steady_clock;
-
-// Centralized logging lives in yy_cybergear/logging.hpp
-inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
-{
-  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
-}
-
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-// Register a wide handler and dispatch frames into all CyberGear mirrors
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << "\n";
-    }
-  });
-}
-
-// Preflight: issue initial requests and wait until all are ready (with retries)
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  // Initial issue of ReadParam and GetDeviceId
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  // Wait for completion with periodic retries
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-// Wait until user presses Enter (or SIGINT occurs). Returns true if Enter was pressed.
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;  // stdin
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);  // 200 ms timeout
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;  // start on Enter
-      // If other characters were typed, keep polling until newline arrives
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+using exmp_helper::Clock;
 
 }  // namespace
 
@@ -287,7 +166,16 @@ int main(int argc, char ** argv)
     yy_cybergear::SPEED_LIMIT, yy_cybergear::POSITION_KP,   yy_cybergear::SPEED_KP,
     yy_cybergear::SPEED_KI,
   };
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
+
+  // Check for errors after preflight sync
+  for (const auto & cg : cgs) {
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Motor faults detected during initialization. Exiting.\n";
+      rt.stop();
+      return EXIT_FAILURE;
+    }
+  }
 
   // Print collected parameters per motor
   std::cout << "\nCollected parameters (including UID, excluding Status):\n";
@@ -296,7 +184,7 @@ int main(int argc, char ** argv)
   }
 
   std::cout << "\nPress Enter to start control (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }
@@ -333,6 +221,16 @@ int main(int argc, char ** argv)
       const auto start = Clock::now();
       const auto deadline = start + dt_ns;
       const double t_now = std::chrono::duration<double>(start - t0).count();
+
+      // Check for errors in all motors and exit if any are found
+      for (const auto & cg : cgs) {
+        if (check_for_errors(cg)) {
+          std::cerr << "ERROR: Stopping all motors due to detected faults.\n";
+          g_running = false;
+          break;
+        }
+      }
+      if (!g_running) break;
 
       // Print snapshot for each motor
       for (const auto & cg : cgs) {
@@ -371,5 +269,6 @@ int main(int argc, char ** argv)
   }
 
   rt.stop();
-  return EXIT_SUCCESS;
+  // Exit with failure if we stopped due to faults
+  return g_running ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/yy_cybergear/example/exmp_06_position_follow.cpp
+++ b/yy_cybergear/example/exmp_06_position_follow.cpp
@@ -41,181 +41,19 @@
 #include "yy_cybergear/logging.hpp"
 #include "yy_socket_can/can_runtime.hpp"
 
+#include "exmp_helper.hpp"
+
 namespace
 {
 std::atomic<bool> g_running{true};
 void handle_sigint(int) { g_running = false; }
-using Clock = std::chrono::steady_clock;
-
-inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
-{
-  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
-}
-inline void print_params(const yy_cybergear::CyberGear & cg)
-{
-  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
-}
-
-inline bool check_for_errors(const yy_cybergear::CyberGear & cg)
-{
-  // Check status frame fault bits (from regular status updates)
-  if (cg.isStatusInitialized()) {
-    const auto status = cg.getStatus();
-    if (status.fault_bits != 0) {
-      std::cerr << "ERROR: Motor 0x" << std::uppercase << std::hex << std::setw(2)
-                << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
-                << " has status fault bits: 0x" << std::uppercase << std::hex << std::setw(2)
-                << std::setfill('0') << static_cast<unsigned>(status.fault_bits) << std::dec
-                << "\n";
-
-      auto fault_strings = yy_cybergear::logging::faultBitsToString(status.fault_bits);
-      for (const auto & fault : fault_strings) {
-        std::cerr << "  - " << fault << "\n";
-      }
-      return true;
-    }
-  }
-
-  // Check aggregate fault/warning bits (from fault/warning responses)
-  const uint32_t fault_bits = cg.fault_bits_agg();
-  const uint32_t warning_bits = cg.warning_bits_agg();
-
-  if (fault_bits != 0) {
-    std::cerr << "ERROR: Motor 0x" << std::uppercase << std::hex << std::setw(2)
-              << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
-              << " has aggregate fault bits: 0x" << std::uppercase << std::hex << std::setw(8)
-              << std::setfill('0') << fault_bits << std::dec << "\n";
-
-    // Decode lower 8 bits using existing fault bit decoder
-    auto fault_strings =
-      yy_cybergear::logging::faultBitsToString(static_cast<uint8_t>(fault_bits & 0xFF));
-    for (const auto & fault : fault_strings) {
-      std::cerr << "  - " << fault << "\n";
-    }
-    return true;
-  }
-
-  if (warning_bits != 0) {
-    std::cerr << "WARNING: Motor 0x" << std::uppercase << std::hex << std::setw(2)
-              << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
-              << " has warning bits: 0x" << std::uppercase << std::hex << std::setw(8)
-              << std::setfill('0') << warning_bits << std::dec << "\n";
-    // Note: For now we don't exit on warnings, only on faults
-  }
-
-  return false;  // No errors detected
-}
-
-inline void register_can_handler(
-  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
-{
-  const uint32_t min_id = 0u;
-  const uint32_t max_id = CAN_EFF_MASK;
-  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
-    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
-    if (verbose) {
-      const uint32_t id = f.can_id & CAN_EFF_MASK;
-      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
-                << " dlc=" << int(f.can_dlc) << "\n";
-    }
-  });
-}
-
-inline void preflight_sync(
-  yy_socket_can::CanRuntime & rt, const std::string & ifname,
-  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
-  bool verbose)
-{
-  for (std::size_t i = 0; i < cgs.size(); ++i) {
-    for (uint16_t idx : preflight_params) {
-      struct can_frame tx
-      {
-      };
-      cgs[i].buildReadParam(idx, tx);
-      rt.post(yy_socket_can::TxRequest{ifname, tx});
-      if (verbose) {
-        const uint32_t id = tx.can_id & CAN_EFF_MASK;
-        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
-                  << std::hex << std::uppercase << idx << std::dec << ")\n";
-      }
-    }
-    struct can_frame tx
-    {
-    };
-    cgs[i].buildGetDeviceId(tx);
-    rt.post(yy_socket_can::TxRequest{ifname, tx});
-    if (verbose) {
-      const uint32_t id = tx.can_id & CAN_EFF_MASK;
-      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
-    }
-  }
-
-  bool all_ready = false;
-  auto last_retry = Clock::now();
-  while (g_running && !all_ready) {
-    all_ready = true;
-    for (const auto & cg : cgs) {
-      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
-        all_ready = false;
-        break;
-      }
-    }
-    if (all_ready) break;
-
-    const auto now = Clock::now();
-    if (now - last_retry >= std::chrono::milliseconds(200)) {
-      last_retry = now;
-      for (std::size_t i = 0; i < cgs.size(); ++i) {
-        const auto & cg = cgs[i];
-        for (uint16_t idx : preflight_params) {
-          if (!cg.isParamInitialized(idx)) {
-            struct can_frame tx
-            {
-            };
-            cgs[i].buildReadParam(idx, tx);
-            rt.post(yy_socket_can::TxRequest{ifname, tx});
-            if (verbose) {
-              const uint32_t id = tx.can_id & CAN_EFF_MASK;
-              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
-                        << ")\n";
-            }
-          }
-        }
-        if (!cg.isUidInitialized()) {
-          struct can_frame tx
-          {
-          };
-          cgs[i].buildGetDeviceId(tx);
-          rt.post(yy_socket_can::TxRequest{ifname, tx});
-          if (verbose) {
-            const uint32_t id = tx.can_id & CAN_EFF_MASK;
-            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
-                      << " (GetDeviceId)\n";
-          }
-        }
-      }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-}
-
-inline bool wait_for_enter_or_sigint()
-{
-  while (g_running) {
-    struct pollfd pfd;
-    pfd.fd = 0;
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    const int pret = ::poll(&pfd, 1, 200);
-    if (pret > 0 && (pfd.revents & POLLIN)) {
-      char ch = 0;
-      const ssize_t n = ::read(0, &ch, 1);
-      if (n > 0 && (ch == '\n' || ch == '\r')) return true;
-    }
-  }
-  return false;
-}
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+using exmp_helper::Clock;
 
 }  // namespace
 
@@ -321,7 +159,7 @@ int main(int argc, char ** argv)
     yy_cybergear::MECHANICAL_POSITION,
     yy_cybergear::MECHANICAL_VELOCITY,
   };
-  preflight_sync(rt, ifname, cgs, preflight_params, verbose);
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
 
   // Check for errors after preflight sync
   for (const auto & cg : cgs) {
@@ -336,7 +174,7 @@ int main(int argc, char ** argv)
   for (const auto & cg : cgs) print_params(cg);
 
   std::cout << "\nPress Enter to start follow (Ctrl+C to exit) ..." << std::endl;
-  if (!wait_for_enter_or_sigint()) {
+  if (!wait_for_enter_or_sigint(g_running)) {
     rt.stop();
     return EXIT_SUCCESS;
   }

--- a/yy_cybergear/example/exmp_helper.hpp
+++ b/yy_cybergear/example/exmp_helper.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <linux/can.h>
+#include <poll.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yy_cybergear/cybergear.hpp"
+#include "yy_cybergear/logging.hpp"
+#include "yy_socket_can/can_runtime.hpp"
+
+namespace exmp_helper
+{
+using Clock = std::chrono::steady_clock;
+
+inline void print_status(const yy_cybergear::CyberGear & cg, double t_sec)
+{
+  std::cout << yy_cybergear::logging::formatStatusLine(cg, t_sec) << '\n';
+}
+
+inline void print_params(const yy_cybergear::CyberGear & cg)
+{
+  std::cout << yy_cybergear::logging::formatParamsSummary(cg);
+}
+
+inline bool check_for_errors(const yy_cybergear::CyberGear & cg)
+{
+  if (cg.isStatusInitialized()) {
+    const auto status = cg.getStatus();
+    if (status.fault_bits != 0) {
+      std::cerr << "ERROR: Motor 0x" << std::uppercase << std::hex << std::setw(2)
+                << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
+                << " has status fault bits: 0x" << std::uppercase << std::hex << std::setw(2)
+                << std::setfill('0') << static_cast<unsigned>(status.fault_bits) << std::dec
+                << "\n";
+
+      auto fault_strings = yy_cybergear::logging::faultBitsToString(status.fault_bits);
+      for (const auto & fault : fault_strings) {
+        std::cerr << "  - " << fault << "\n";
+      }
+      return true;
+    }
+  }
+
+  const uint32_t fault_bits = cg.fault_bits_agg();
+  const uint32_t warning_bits = cg.warning_bits_agg();
+
+  if (fault_bits != 0) {
+    std::cerr << "ERROR: Motor 0x" << std::uppercase << std::hex << std::setw(2)
+              << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
+              << " has aggregate fault bits: 0x" << std::uppercase << std::hex << std::setw(8)
+              << std::setfill('0') << fault_bits << std::dec << "\n";
+
+    auto fault_strings =
+      yy_cybergear::logging::faultBitsToString(static_cast<uint8_t>(fault_bits & 0xFF));
+    for (const auto & fault : fault_strings) {
+      std::cerr << "  - " << fault << "\n";
+    }
+    return true;
+  }
+
+  if (warning_bits != 0) {
+    std::cerr << "WARNING: Motor 0x" << std::uppercase << std::hex << std::setw(2)
+              << std::setfill('0') << static_cast<unsigned>(cg.motor_id()) << std::dec
+              << " has warning bits: 0x" << std::uppercase << std::hex << std::setw(8)
+              << std::setfill('0') << warning_bits << std::dec << "\n";
+  }
+
+  return false;
+}
+
+inline void register_can_handler(
+  yy_socket_can::CanRuntime & rt, std::vector<yy_cybergear::CyberGear> & cgs, bool verbose)
+{
+  const uint32_t min_id = 0u;
+  const uint32_t max_id = CAN_EFF_MASK;
+  rt.registerHandler(min_id, max_id, [verbose, &cgs](const struct can_frame & f) {
+    for (auto & cg : cgs) (void)cg.dispatchAndUpdate(f);
+    if (verbose) {
+      const uint32_t id = f.can_id & CAN_EFF_MASK;
+      std::cout << "RX 0x" << std::hex << std::uppercase << id << std::dec
+                << " dlc=" << int(f.can_dlc) << "\n";
+    }
+  });
+}
+
+inline void preflight_sync(
+  std::atomic<bool> & running, yy_socket_can::CanRuntime & rt, const std::string & ifname,
+  std::vector<yy_cybergear::CyberGear> & cgs, const std::vector<uint16_t> & preflight_params,
+  bool verbose)
+{
+  for (std::size_t i = 0; i < cgs.size(); ++i) {
+    for (uint16_t idx : preflight_params) {
+      struct can_frame tx
+      {
+      };
+      cgs[i].buildReadParam(idx, tx);
+      rt.post(yy_socket_can::TxRequest{ifname, tx});
+      if (verbose) {
+        const uint32_t id = tx.can_id & CAN_EFF_MASK;
+        std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (ReadParam 0x"
+                  << std::hex << std::uppercase << idx << std::dec << ")\n";
+      }
+    }
+    struct can_frame tx
+    {
+    };
+    cgs[i].buildGetDeviceId(tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (GetDeviceId)\n";
+    }
+  }
+
+  bool all_ready = false;
+  auto last_retry = Clock::now();
+  while (running.load() && !all_ready) {
+    all_ready = true;
+    for (const auto & cg : cgs) {
+      if (!cg.isInitializedFor(preflight_params, /*require_uid=*/true)) {
+        all_ready = false;
+        break;
+      }
+    }
+    if (all_ready) break;
+
+    const auto now = Clock::now();
+    if (now - last_retry >= std::chrono::milliseconds(200)) {
+      last_retry = now;
+      for (std::size_t i = 0; i < cgs.size(); ++i) {
+        const auto & cg = cgs[i];
+        for (uint16_t idx : preflight_params) {
+          if (!cg.isParamInitialized(idx)) {
+            struct can_frame tx
+            {
+            };
+            cgs[i].buildReadParam(idx, tx);
+            rt.post(yy_socket_can::TxRequest{ifname, tx});
+            if (verbose) {
+              const uint32_t id = tx.can_id & CAN_EFF_MASK;
+              std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
+                        << " (ReadParam 0x" << std::hex << std::uppercase << idx << std::dec
+                        << ")\n";
+            }
+          }
+        }
+        if (!cg.isUidInitialized()) {
+          struct can_frame tx
+          {
+          };
+          cgs[i].buildGetDeviceId(tx);
+          rt.post(yy_socket_can::TxRequest{ifname, tx});
+          if (verbose) {
+            const uint32_t id = tx.can_id & CAN_EFF_MASK;
+            std::cout << "RETRY TX 0x" << std::hex << std::uppercase << id << std::dec
+                      << " (GetDeviceId)\n";
+          }
+        }
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+}
+
+inline bool wait_for_enter_or_sigint(std::atomic<bool> & running)
+{
+  while (running.load()) {
+    struct pollfd pfd;
+    pfd.fd = 0;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    const int pret = ::poll(&pfd, 1, 200);
+    if (pret > 0 && (pfd.revents & POLLIN)) {
+      char ch = 0;
+      const ssize_t n = ::read(0, &ch, 1);
+      if (n > 0 && (ch == '\n' || ch == '\r')) return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace exmp_helper
+

--- a/yy_cybergear/example/exmp_helper.hpp
+++ b/yy_cybergear/example/exmp_helper.hpp
@@ -60,7 +60,7 @@ inline bool check_for_errors(const yy_cybergear::CyberGear & cg)
               << std::setfill('0') << fault_bits << std::dec << "\n";
 
     auto fault_strings =
-      yy_cybergear::logging::faultBitsToString(static_cast<uint8_t>(fault_bits & 0xFF));
+      yy_cybergear::logging::faultBitsToString(fault_bits);
     for (const auto & fault : fault_strings) {
       std::cerr << "  - " << fault << "\n";
     }

--- a/yy_cybergear/package.xml
+++ b/yy_cybergear/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yy_cybergear</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>CyberGear Cpp Driver</description>
   <maintainer email="yuki8mamo10.hu@gmail.com">yuki yamamoto</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
This pull request refactors the motor control example files to centralize shared helper functions into a new `exmp_helper.hpp` header. It also adds improved error detection and handling in the initialization and main control loops, ensuring that motor faults are detected early and the program exits with an appropriate status if faults are found. These changes improve code maintainability and robustness across all example files.

### Codebase refactoring and centralization
* Moved shared helper functions (`print_status`, `print_params`, `register_can_handler`, `preflight_sync`, `wait_for_enter_or_sigint`, and `Clock` alias) from each example file (`exmp_01_monitor_status.cpp`, `exmp_02_operation_sin_wave.cpp`, `exmp_03_position_sin_wave.cpp`) into the new centralized header `exmp_helper.hpp`, and updated usages to import them from the helper namespace. [[1]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6R39-R52) [[2]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7R47-R60) [[3]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aR47-R55) [[4]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aL64-R70)

### Error detection and handling
* Added calls to `check_for_errors` after preflight synchronization in all examples, causing the program to exit with an error message and failure status if any motor faults are detected during initialization. [[1]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6L286-R182) [[2]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7L318-R206) [[3]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aL312-R219)
* Inserted periodic error checks in the main control/monitoring loops of all examples. If a fault is detected in any motor, the program prints an error message, stops the runtime, and exits with failure. [[1]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6R195-R204) [[2]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7R255-R264) [[3]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aR274-R283)
* Updated exit status logic so that the program returns `EXIT_FAILURE` if it stopped due to detected faults, otherwise returns `EXIT_SUCCESS`. [[1]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6L329-R228) [[2]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7L413-R312)

### API changes for helpers
* Changed the signatures of `preflight_sync` and `wait_for_enter_or_sigint` to accept the atomic `g_running` flag, improving signal handling and program flow control. [[1]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6L286-R182) [[2]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7L318-R206) [[3]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aL312-R219) [[4]](diffhunk://#diff-bfea99c3ead2dc35d85f55de8cd3fddd7f89be880b34647639906ca31e758bd6L286-R182) [[5]](diffhunk://#diff-b17fb9a09e05e3dc1f73ee25c292aa409d1538805bb2cf5602aa4bc9971b6eb7L327-R215) [[6]](diffhunk://#diff-16932757075fd56a4ebef6160f2b7cb81c9ff7a3814dafe514eb2ea5f4d7f35aL312-R219)

---

These changes make the example code easier to maintain, ensure consistent error handling, and improve reliability when running motor control demos.