### PR TITLE
Feat/param setter

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -13,6 +13,7 @@
     "exmp",
     "gtest",
     "htmlcov",
+    "IFACE",
     "libqt",
     "Mbps",
     "nosetests",
@@ -21,6 +22,7 @@
     "pytest",
     "sdist",
     "SIOCGIFINDEX",
+    "txqueuelen",
     "Undervoltage",
     "vcstool",
     "yycdf"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@
 - `yy_socket_can`: SocketCANラッパー。ノンブロッキング/バッファ設定/ループバック切り替えを提供します。
 - `yy_cybergear`: CyberGear 固有プロトコルの実装。操作コマンド生成、ステータス受信、パラメータ読み書き API を持ち、`exmp_*` の CLI サンプルを同梱しています。
 
+## ツール
+
+- `tools/up.bash`
+  - CAN インターフェース (`can0` 既定) の初期化を一括実行するスクリプトです。
+  - ビットレートや `txqueuelen` を設定し、インターフェースを UP 状態にします。既に UP の場合は安全に DOWN → 再設定 → UP を行います。
+  - 実行例:
+
+    ```bash
+    ./tools/up.bash           # デフォルト設定 (1 Mbps, txqueuelen=1000)
+    IFACE=can1 ./tools/up.bash # IFACE 変数を上書きして別デバイスを初期化
+    ```
+
 ## ビルド手順
 
 1. ワークスペースを作成して、`[ワークスペース]/src`に本リポジトリをクローンします。
@@ -26,21 +38,38 @@
 
 ## 使い方
 
-- SocketCANの準備
+- CAN インターフェースの準備
 
-  ```bash
-  sudo ip link set can0 down
-  sudo ip link set can0 up type can bitrate 1000000
-  ip -details link show can0
-  ```
-
-- サンプルプログラムの実行方法
-
-  - ステータス監視:
+  - `tools/up.bash` を使うと、ビットレート設定から状態確認までをまとめて実行できます。
 
     ```bash
-    ./build/yy_cybergear/exmp_01_monitor_status --interface can0 --motor-id 1
+    ./tools/up.bash
     ```
+
+  - 手作業で行う場合:
+
+    ```bash
+    sudo ip link set can0 down
+    sudo ip link set can0 up type can bitrate 1000000
+    ip -details link show can0
+    ```
+
+- サンプルバイナリ
+
+  - すべて `./build/yy_cybergear/<バイナリ名>` に生成されます。`--interface/-i` (既定 `can0`) と `--motor-id/-M` で対象デバイスを指定し、`Ctrl+C` で終了します。
+  - 共通機能として、ほとんどのサンプルが以下を実装しています。
+    - 起動時に `yy_socket_can::CanRuntime` を介して複数モーターを登録
+    - 必要な CyberGear パラメータの ReadParam を送信し、取得完了まで待機
+    - ステータス/警告/フォルトを検出して標準出力に整形表示
+
+  - 各サンプルの詳細:
+    - `exmp_00_zero_position`: 単体モーターを対象に、任意のパラメータ書き込み (速度/電流/トルク制限やゲインなど) → 機械ゼロ点の取得 → 指定秒数ゼロ位置保持を順番に実施します。`--speed-limit` や `--position-kp` などで書き込み値を指定できます。
+    - `exmp_01_monitor_status`: 1 台以上のモーターに対してステータスフレーム (Type 2) を監視し続け、エラー／警告ビットを常時チェックします。`-M` を複数指定すれば集合監視が可能です。
+    - `exmp_02_operation_sin_wave`: 複数モーターへ操作コマンド (Type 1) を周期送信し、位置・速度・トルクを正弦波で変化させるランコントロールの例です。`--amp`, `--freq`, `--kp`, `--kd` などで波形とゲインを設定します。
+    - `exmp_03_position_sin_wave`: CyberGear の `POSITION_REFERENCE` を直接書き換え、正弦波位置指令を生成するポジション制御デモです。`--phase-step-deg` でモーターごとに位相をずらし、同期動作を試せます。
+    - `exmp_04_speed_constant`: 各モーターに一定速度 (`SPEED_REFERENCE`) を与えるサンプルです。`-s/--speed` で正負を含む速度指令を設定でき、ウォームアップや通信テストに向きます。
+    - `exmp_05_current_constant`: 電流モード (`IQ_REFERENCE`) で一定 q 軸電流を与え続ける例です。電流ループの検証や推力ゼロ点測定に利用できます。
+    - `exmp_06_position_follow`: 最も ID が小さいモーターをマスターとし、他のモーターをその機械角に追従させるサンプルです。複数台の同期動作の確認に使用します。
 
 ## テスト
 

--- a/tools/up.bash
+++ b/tools/up.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ============================================
+# SocketCAN can0 interface initialization script
+# ============================================
+
+# Settings
+IFACE="can0"
+BITRATE=1000000     # 1Mbps
+TX_QUEUE_LEN=1000   # TX queue length (default is ~10; increased)
+
+echo "🔧 Setting up $IFACE (bitrate=${BITRATE}, txqueuelen=${TX_QUEUE_LEN})..."
+
+# If the interface is already UP, bring it DOWN to reset
+if ip link show "$IFACE" 2>/dev/null | grep -q "UP"; then
+    echo "⚙️  $IFACE is currently UP. Bringing it down first..."
+    sudo ip link set "$IFACE" down
+    sleep 0.2
+fi
+
+# Configure interface bitrate
+echo "⚙️  Configuring CAN bitrate..."
+sudo ip link set "$IFACE" type can bitrate "$BITRATE"
+
+# Increase transmit queue length
+echo "⚙️  Setting txqueuelen to $TX_QUEUE_LEN..."
+sudo ip link set "$IFACE" txqueuelen "$TX_QUEUE_LEN"
+
+# Bring interface UP
+echo "🚀 Bringing $IFACE UP..."
+sudo ip link set "$IFACE" up
+
+# Check interface status
+echo "✅ Checking interface status..."
+ip -details link show "$IFACE"
+
+echo "✅ $IFACE is now UP and ready!"

--- a/yy_cybergear/CMakeLists.txt
+++ b/yy_cybergear/CMakeLists.txt
@@ -19,6 +19,11 @@ ament_auto_add_library(${TARGET} SHARED
 )
 unset(TARGET)
 
+# exmp_00_zero_position ============================
+set(TARGET exmp_00_zero_position)
+ament_auto_add_executable(${TARGET} example/${TARGET}.cpp)
+unset(TARGET)
+
 # exmp_01_monitor_status ============================
 set(TARGET exmp_01_monitor_status)
 ament_auto_add_executable(${TARGET} example/${TARGET}.cpp)

--- a/yy_cybergear/example/exmp_00_zero_position.cpp
+++ b/yy_cybergear/example/exmp_00_zero_position.cpp
@@ -1,0 +1,364 @@
+// Copyright 2025 Yuki Yamamoto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// exmp_00: guide a single motor through parameter setup, mechanical zeroing,
+// and a short hold at zero position using the CyberGear helper with CanRuntime.
+
+#include <linux/can.h>
+#include <poll.h>
+#include <unistd.h>
+
+#include <CLI/CLI.hpp>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yy_cybergear/cybergear.hpp"
+#include "yy_cybergear/logging.hpp"
+#include "yy_socket_can/can_runtime.hpp"
+
+#include "exmp_helper.hpp"
+
+namespace
+{
+std::atomic<bool> g_running{true};
+void handle_sigint(int) { g_running = false; }
+
+using exmp_helper::Clock;
+using exmp_helper::check_for_errors;
+using exmp_helper::preflight_sync;
+using exmp_helper::print_params;
+using exmp_helper::print_status;
+using exmp_helper::register_can_handler;
+using exmp_helper::wait_for_enter_or_sigint;
+
+void sleep_until_or_abort(const Clock::time_point & deadline, Clock::duration poll)
+{
+  while (g_running && Clock::now() + poll < deadline) {
+    std::this_thread::sleep_for(poll);
+  }
+  if (g_running) {
+    std::this_thread::sleep_until(deadline);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  CLI::App app{"exmp_00: set key parameters, capture mechanical zero, and drive to zero"};
+
+  std::string ifname{"can0"};
+  std::string host_id_str{"0x00"};
+  std::string motor_id_str{"0x01"};
+  bool verbose = false;
+
+  std::optional<double> speed_limit;
+  std::optional<double> current_limit;
+  std::optional<double> torque_limit;
+  std::optional<double> position_kp;
+  std::optional<double> speed_kp;
+  std::optional<double> speed_ki;
+
+  int status_rate_hz = 20;
+  double hold_duration_sec = 3.0;  // time to hold zero after enable
+
+  app.add_option("-i,--interface", ifname, "CAN interface (e.g., can0)")
+    ->capture_default_str();
+  app.add_option("-H,--host-id", host_id_str, "Host ID (decimal or 0x-prefixed hex)")
+    ->capture_default_str();
+  app.add_option("-M,--motor-id", motor_id_str, "Motor ID (decimal or 0x-prefixed hex)")
+    ->capture_default_str();
+  app.add_flag("-v,--verbose", verbose, "Verbose CAN frame prints");
+
+  app.add_option("--speed-limit", speed_limit, "Write SPEED_LIMIT [rad/s]")
+    ->check(CLI::NonNegativeNumber);
+  app.add_option("--current-limit", current_limit, "Write CURRENT_LIMIT [A]")
+    ->check(CLI::NonNegativeNumber);
+  app.add_option("--torque-limit", torque_limit, "Write TORQUE_LIMIT [Nm]")
+    ->check(CLI::NonNegativeNumber);
+  app.add_option("--position-kp", position_kp, "Write POSITION_KP (dimensionless)")
+    ->check(CLI::NonNegativeNumber);
+  app.add_option("--speed-kp", speed_kp, "Write SPEED_KP (dimensionless)")
+    ->check(CLI::NonNegativeNumber);
+  app.add_option("--speed-ki", speed_ki, "Write SPEED_KI (dimensionless)")
+    ->check(CLI::NonNegativeNumber);
+
+  app.add_option("--hold-sec", hold_duration_sec, "Duration to hold zero after enable [s]")
+    ->check(CLI::NonNegativeNumber)
+    ->capture_default_str();
+  app.add_option("--status-rate", status_rate_hz, "Status print rate during hold [Hz]")
+    ->check(CLI::PositiveNumber)
+    ->capture_default_str();
+
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError & e) {
+    return app.exit(e);
+  }
+
+  unsigned long host_ul = 0;
+  unsigned long motor_ul = 0;
+  try {
+    host_ul = std::stoul(host_id_str, nullptr, 0);
+    motor_ul = std::stoul(motor_id_str, nullptr, 0);
+  } catch (const std::exception & e) {
+    std::cerr << "Invalid ID: " << e.what() << '\n';
+    return EXIT_FAILURE;
+  }
+  if (host_ul > 0xFFul || motor_ul > 0xFFul) {
+    std::cerr << "Host and motor IDs must be 0..255 (got host=" << host_ul << ", motor="
+              << motor_ul << ")\n";
+    return EXIT_FAILURE;
+  }
+  const uint8_t host = static_cast<uint8_t>(host_ul & 0xFFu);
+  const uint8_t motor = static_cast<uint8_t>(motor_ul & 0xFFu);
+
+  std::signal(SIGINT, handle_sigint);
+  std::signal(SIGTERM, handle_sigint);
+
+  yy_socket_can::CanRuntime rt;
+  rt.setWarningLogger([](const std::string & m) { std::cerr << m << std::endl; });
+  rt.addChannel(ifname);
+
+  std::vector<yy_cybergear::CyberGear> cgs;
+  cgs.emplace_back(host, motor);
+  auto & cg = cgs.front();
+
+  register_can_handler(rt, cgs, verbose);
+  rt.start();
+
+  const auto t0 = Clock::now();
+
+  std::cout << "exmp_00 on " << ifname << " targeting motor 0x" << std::uppercase << std::hex
+            << std::setw(2) << std::setfill('0') << static_cast<unsigned>(motor) << std::dec
+            << ". Optional parameter writes will be applied before zeroing.\n";
+
+  const std::vector<uint16_t> preflight_params = {
+    yy_cybergear::RUN_MODE,
+    yy_cybergear::SPEED_LIMIT,
+    yy_cybergear::CURRENT_LIMIT,
+    yy_cybergear::TORQUE_LIMIT,
+    yy_cybergear::POSITION_KP,
+    yy_cybergear::SPEED_KP,
+    yy_cybergear::SPEED_KI,
+    yy_cybergear::POSITION_REFERENCE,
+    yy_cybergear::MECHANICAL_POSITION,
+    yy_cybergear::CURRENT_KP,
+    yy_cybergear::CURRENT_KI,
+    yy_cybergear::CURRENT_FILTER_GAIN,
+  };
+  preflight_sync(g_running, rt, ifname, cgs, preflight_params, verbose);
+  if (!g_running) {
+    rt.stop();
+    return EXIT_SUCCESS;
+  }
+
+  if (check_for_errors(cg)) {
+    std::cerr << "ERROR: Motor reported faults during initialization.\n";
+    rt.stop();
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "\nInitial parameters:\n";
+  print_params(cg);
+
+  using SetterFn = void (yy_cybergear::CyberGear::*)(float, struct can_frame &) const noexcept;
+  auto maybe_write_param = [&](const std::optional<double> & value, SetterFn setter,
+                               uint16_t index, const std::string & label) {
+    if (!value) return;
+    const float fvalue = static_cast<float>(*value);
+    std::cout << "Writing " << label << " = " << *value << '\n';
+    struct can_frame tx
+    {
+    };
+    (cg.*setter)(fvalue, tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (Write "
+                << label << ")\n";
+    }
+    struct can_frame read_tx
+    {
+    };
+    cg.buildReadParam(index, read_tx);
+    rt.post(yy_socket_can::TxRequest{ifname, read_tx});
+    if (verbose) {
+      const uint32_t id = read_tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (Read " << label
+                << ")\n";
+    }
+  };
+
+  maybe_write_param(speed_limit, &yy_cybergear::CyberGear::buildSetSpeedLimit,
+                    yy_cybergear::SPEED_LIMIT, "SPEED_LIMIT");
+  maybe_write_param(current_limit, &yy_cybergear::CyberGear::buildSetCurrentLimit,
+                    yy_cybergear::CURRENT_LIMIT, "CURRENT_LIMIT");
+  maybe_write_param(torque_limit, &yy_cybergear::CyberGear::buildSetTorqueLimit,
+                    yy_cybergear::TORQUE_LIMIT, "TORQUE_LIMIT");
+  maybe_write_param(position_kp, &yy_cybergear::CyberGear::buildSetPositionKp,
+                    yy_cybergear::POSITION_KP, "POSITION_KP");
+  maybe_write_param(speed_kp, &yy_cybergear::CyberGear::buildSetSpeedKp,
+                    yy_cybergear::SPEED_KP, "SPEED_KP");
+  maybe_write_param(speed_ki, &yy_cybergear::CyberGear::buildSetSpeedKi,
+                    yy_cybergear::SPEED_KI, "SPEED_KI");
+
+  if (speed_limit || current_limit || torque_limit || position_kp || speed_kp || speed_ki) {
+    std::cout << "Waiting for parameter write responses..." << std::endl;
+    sleep_until_or_abort(Clock::now() + std::chrono::milliseconds(300), std::chrono::milliseconds(20));
+  }
+
+  if (check_for_errors(cg)) {
+    std::cerr << "ERROR: Motor reported faults after parameter writes.\n";
+    rt.stop();
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "\nUpdated parameters:\n";
+  print_params(cg);
+
+  std::cout << "\nAlign the motor to your desired zero position, then press Enter to store mechanical zero (Ctrl+C to abort)." << std::endl;
+  if (!wait_for_enter_or_sigint(g_running)) {
+    rt.stop();
+    return EXIT_SUCCESS;
+  }
+  if (!g_running) {
+    rt.stop();
+    return EXIT_SUCCESS;
+  }
+
+  {
+    struct can_frame tx
+    {
+    };
+    cg.buildSetMechanicalZero(tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    std::cout << "Mechanical zero command sent." << std::endl;
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (SetMechanicalZero)\n";
+    }
+  }
+
+  {
+    struct can_frame tx
+    {
+    };
+    cg.buildReadParam(yy_cybergear::MECHANICAL_POSITION, tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec
+                << " (Read MECHANICAL_POSITION)\n";
+    }
+  }
+
+  sleep_until_or_abort(Clock::now() + std::chrono::milliseconds(200), std::chrono::milliseconds(20));
+
+  if (check_for_errors(cg)) {
+    std::cerr << "ERROR: Motor reported faults after zeroing command.\n";
+    rt.stop();
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "\nPress Enter to enable the motor and drive/hold at zero (Ctrl+C to abort)." << std::endl;
+  if (!wait_for_enter_or_sigint(g_running)) {
+    rt.stop();
+    return EXIT_SUCCESS;
+  }
+  if (!g_running) {
+    rt.stop();
+    return EXIT_SUCCESS;
+  }
+
+  {
+    struct can_frame tx
+    {
+    };
+    cg.buildSetRunMode(yy_cybergear::RunMode::Position, tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec
+                << " (Write RUN_MODE=Position)\n";
+    }
+  }
+  {
+    struct can_frame tx
+    {
+    };
+    cg.buildEnable(tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (Enable)\n";
+    }
+  }
+
+  const std::chrono::nanoseconds dt_ns{
+    static_cast<long long>(1e9 / std::max(1, status_rate_hz))};
+  const auto hold_deadline = Clock::now() + std::chrono::duration<double>(hold_duration_sec);
+
+  while (g_running && Clock::now() < hold_deadline) {
+    const auto loop_start = Clock::now();
+    const double t_now = std::chrono::duration<double>(loop_start - t0).count();
+
+    if (check_for_errors(cg)) {
+      std::cerr << "ERROR: Fault detected during zero hold. Aborting." << std::endl;
+      g_running = false;
+      break;
+    }
+
+    print_status(cg, t_now);
+
+    struct can_frame tx
+    {
+    };
+    cg.buildSetPositionReference(0.0f, tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec
+                << " (Write POSITION_REFERENCE=0)\n";
+    }
+
+    sleep_until_or_abort(loop_start + dt_ns, std::chrono::milliseconds(5));
+  }
+
+  {
+    struct can_frame tx
+    {
+    };
+    cg.buildStop(tx);
+    rt.post(yy_socket_can::TxRequest{ifname, tx});
+    if (verbose) {
+      const uint32_t id = tx.can_id & CAN_EFF_MASK;
+      std::cout << "TX 0x" << std::hex << std::uppercase << id << std::dec << " (Stop)\n";
+    }
+  }
+
+  rt.stop();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request introduces a new initialization script for CAN interfaces, improves documentation for easier setup and usage, and adds a new example binary for CyberGear motor zeroing. The changes are grouped as follows:

**Tooling and Interface Initialization:**

* Added `tools/up.bash`, a script for automated SocketCAN interface setup, including bitrate and `txqueuelen` configuration, with safe reset if the interface is already up.
* Updated `.vscode/cspell.json` to whitelist new technical terms (`IFACE`, `txqueuelen`) relevant to CAN interface configuration. [[1]](diffhunk://#diff-d9f1a54e1f1a4c8324f4756f08a6af27671a3ae9312190d4a5fe981cc1722824R16) [[2]](diffhunk://#diff-d9f1a54e1f1a4c8324f4756f08a6af27671a3ae9312190d4a5fe981cc1722824R25)

**Documentation Improvements:**

* Expanded `README.md` with a new "ツール" section describing `tools/up.bash`, usage examples, and clarified CAN interface preparation steps. Also improved sample binary documentation, detailing usage and features for each example. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R73)

**CyberGear Example Expansion:**

* Added new example binary `exmp_00_zero_position` to the build system (`yy_cybergear/CMakeLists.txt`).
* Implemented `exmp_00_zero_position.cpp`, a comprehensive sample guiding users through parameter setup, mechanical zeroing, and holding a motor at zero using CyberGear and SocketCAN.